### PR TITLE
feat: add hamburger menu for mobile header

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -34,6 +34,33 @@ body {
   padding: 16px 24px;
   background: var(--bg-card);
   border-bottom: 1px solid var(--border);
+  position: relative;
+}
+
+.nav-secondary-actions {
+  display: flex;
+  gap: 16px;
+}
+
+.hamburger-btn {
+  display: none;
+  flex-direction: column;
+  justify-content: center;
+  gap: 5px;
+  padding: 8px;
+  background: var(--border);
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.hamburger-btn span {
+  display: block;
+  width: 20px;
+  height: 2px;
+  background: var(--text);
+  border-radius: 2px;
 }
 
 .navbar h1 {
@@ -475,4 +502,24 @@ details.advanced-section summary:hover {
   .server-grid { grid-template-columns: 1fr; }
   .form-row { grid-template-columns: 1fr; }
   .console-output { height: 350px; }
+
+  .hamburger-btn { display: flex; }
+
+  .nav-secondary-actions {
+    display: none;
+    position: absolute;
+    top: 100%;
+    right: 0;
+    left: 0;
+    flex-direction: column;
+    background: var(--bg-card);
+    border-bottom: 1px solid var(--border);
+    padding: 12px 16px;
+    gap: 10px;
+    z-index: 50;
+  }
+
+  .nav-secondary-actions.open { display: flex; }
+
+  .nav-secondary-actions .btn { width: 100%; justify-content: center; }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -10,9 +10,14 @@
   <nav class="navbar">
     <h1>MC Server Manager</h1>
     <span class="spacer"></span>
-    <button class="btn btn-secondary" id="add-template-btn">Add Template</button>
-    <button class="btn btn-secondary" id="import-server-btn">Import Server</button>
+    <div class="nav-secondary-actions" id="nav-secondary-actions">
+      <button class="btn btn-secondary" id="add-template-btn">Add Template</button>
+      <button class="btn btn-secondary" id="import-server-btn">Import Server</button>
+    </div>
     <button class="btn btn-primary" id="add-server-btn">Add Server</button>
+    <button class="hamburger-btn" id="hamburger-btn" aria-label="More options" aria-expanded="false">
+      <span></span><span></span><span></span>
+    </button>
   </nav>
 
   <main class="dashboard-content">

--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -387,6 +387,21 @@ function showImportConfigure(data) {
   document.getElementById('confirm-import').disabled = false;
 }
 
+// --- Hamburger menu (mobile) ---
+const hamburgerBtn = document.getElementById('hamburger-btn');
+const navSecondaryActions = document.getElementById('nav-secondary-actions');
+
+hamburgerBtn.addEventListener('click', (e) => {
+  e.stopPropagation();
+  const isOpen = navSecondaryActions.classList.toggle('open');
+  hamburgerBtn.setAttribute('aria-expanded', String(isOpen));
+});
+
+document.addEventListener('click', () => {
+  navSecondaryActions.classList.remove('open');
+  hamburgerBtn.setAttribute('aria-expanded', 'false');
+});
+
 document.getElementById('confirm-import').onclick = () => {
   const customArgs = document.getElementById('imp-custom-args').value.trim();
   const selected = impFilePicker.querySelector('input[name="imp-jar"]:checked');


### PR DESCRIPTION
Move "Add Template" and "Import Server" buttons into a dropdown menu triggered by a hamburger button on mobile screens (≤600px), keeping the header clean while "Add Server" remains always visible.

Closes #1

Generated with [Claude Code](https://claude.ai/code)