### PR TITLE
feat: add View Templates modal with template deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ If no `template.json` exists, defaults to standard mode with `server.jar`.
 
 Click "Add Template" on the dashboard to upload a ZIP file. After upload, either select a `.jar` file for standard mode, or enter custom Java arguments for modded servers (e.g. NeoForge). The `template.json` is created automatically.
 
+### Managing Templates via GUI
+
+Click "View Templates" on the dashboard to see all available templates with their readiness status. From this view you can delete any template. Deleting a template does not affect servers already created from it.
+
 ## Importing Existing Servers
 
 Click "Import Server" on the dashboard to import an existing Minecraft server from a ZIP file. This creates a server instance directly from your existing server files — preserving world data, mods, plugins, and configuration.
@@ -201,6 +205,7 @@ All settings are configurable via environment variables:
 | `upload-server-icon` | `{ serverId, imageData: ArrayBuffer }` | Upload custom 64x64 server icon |
 | `finalize-template` | `{ name, serverJar }` | Confirm template with chosen server jar |
 | `cancel-template-upload` | `{ name }` | Cancel pending template upload |
+| `delete-template` | `{ name }` | Delete a template directory (callback) |
 | `finalize-import` | `{ importId, name, serverJar?, customArgs?, port?, minRam?, maxRam? }` | Confirm server import with chosen jar/args |
 | `cancel-import` | `{ importId }` | Cancel pending server import |
 

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -98,6 +98,21 @@ body {
 .btn-primary { background: var(--accent); color: #fff; }
 .btn-danger { background: var(--danger); color: #fff; }
 .btn-secondary { background: var(--border); color: var(--text); }
+.btn-sm { padding: 4px 10px; font-size: 0.8rem; }
+
+/* Template list rows */
+.template-list-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--border);
+}
+.template-list-row:last-child { border-bottom: none; }
+.template-list-name { flex: 1; font-size: 0.9rem; }
+.template-list-status { font-size: 0.78rem; padding: 2px 7px; border-radius: 4px; }
+.template-list-status.ready { background: rgba(74,222,128,0.15); color: #4ade80; }
+.template-list-status.not-ready { background: rgba(255,165,0,0.15); color: orange; }
 
 /* Server card grid */
 .dashboard-content { padding: 24px; }

--- a/public/index.html
+++ b/public/index.html
@@ -12,6 +12,7 @@
     <span class="spacer"></span>
     <div class="nav-secondary-actions" id="nav-secondary-actions">
       <button class="btn btn-secondary" id="add-template-btn">Add Template</button>
+      <button class="btn btn-secondary" id="view-templates-btn">View Templates</button>
       <button class="btn btn-secondary" id="import-server-btn">Import Server</button>
     </div>
     <button class="btn btn-primary" id="add-server-btn">Add Server</button>
@@ -243,6 +244,18 @@
           <button type="button" class="btn btn-secondary" id="cancel-import-configure">Cancel</button>
           <button type="button" class="btn btn-primary" id="confirm-import">Import Server</button>
         </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- View Templates Modal -->
+  <div class="modal-overlay" id="view-templates-modal-overlay">
+    <div class="modal">
+      <h2>Templates</h2>
+      <div id="view-templates-list" style="min-height:60px"></div>
+      <div class="form-error" id="view-templates-error"></div>
+      <div class="form-actions">
+        <button type="button" class="btn btn-secondary" id="close-view-templates-modal">Close</button>
       </div>
     </div>
   </div>

--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -387,6 +387,60 @@ function showImportConfigure(data) {
   document.getElementById('confirm-import').disabled = false;
 }
 
+// --- View Templates Modal ---
+const viewTemplatesModalOverlay = document.getElementById('view-templates-modal-overlay');
+const viewTemplatesList = document.getElementById('view-templates-list');
+const viewTemplatesError = document.getElementById('view-templates-error');
+
+document.getElementById('view-templates-btn').onclick = openViewTemplatesModal;
+document.getElementById('close-view-templates-modal').onclick = closeViewTemplatesModal;
+viewTemplatesModalOverlay.onclick = (e) => { if (e.target === viewTemplatesModalOverlay) closeViewTemplatesModal(); };
+
+function openViewTemplatesModal() {
+  viewTemplatesError.textContent = '';
+  viewTemplatesList.innerHTML = '<p style="color:var(--text-muted);font-size:0.85rem">Loading...</p>';
+  viewTemplatesModalOverlay.classList.add('active');
+  refreshViewTemplatesList();
+}
+
+function closeViewTemplatesModal() {
+  viewTemplatesModalOverlay.classList.remove('active');
+}
+
+function refreshViewTemplatesList() {
+  socket.emit('list-templates', (templates) => {
+    viewTemplatesError.textContent = '';
+    if (templates.length === 0) {
+      viewTemplatesList.innerHTML = '<p style="color:var(--text-muted);font-size:0.85rem">No templates found.</p>';
+      return;
+    }
+    viewTemplatesList.innerHTML = templates.map(t => `
+      <div class="template-list-row" data-name="${esc(t.name)}">
+        <span class="template-list-name">${esc(t.name)}</span>
+        <span class="template-list-status ${t.hasJar ? 'ready' : 'not-ready'}">${t.hasJar ? 'Ready' : 'Not ready'}</span>
+        <button class="btn btn-danger btn-sm delete-template-btn" data-name="${esc(t.name)}">Delete</button>
+      </div>
+    `).join('');
+
+    viewTemplatesList.querySelectorAll('.delete-template-btn').forEach(btn => {
+      btn.onclick = () => deleteTemplate(btn.dataset.name, btn);
+    });
+  });
+}
+
+function deleteTemplate(name, btn) {
+  if (!confirm(`Delete template "${name}"? This cannot be undone.`)) return;
+  btn.disabled = true;
+  socket.emit('delete-template', { name }, (res) => {
+    if (res.ok) {
+      refreshViewTemplatesList();
+    } else {
+      viewTemplatesError.textContent = res.error;
+      btn.disabled = false;
+    }
+  });
+}
+
 // --- Hamburger menu (mobile) ---
 const hamburgerBtn = document.getElementById('hamburger-btn');
 const navSecondaryActions = document.getElementById('nav-secondary-actions');

--- a/src/index.js
+++ b/src/index.js
@@ -198,6 +198,15 @@ io.on('connection', (socket) => {
     }
   });
 
+  socket.on('delete-template', (data, callback) => {
+    try {
+      manager.deleteTemplate(data.name);
+      callback({ ok: true });
+    } catch (err) {
+      callback({ ok: false, error: err.message });
+    }
+  });
+
   // Import server finalize/cancel (upload is handled via HTTP POST /api/import-server)
   socket.on('finalize-import', (data, callback) => {
     try {

--- a/src/services/ServerManager.js
+++ b/src/services/ServerManager.js
@@ -336,6 +336,20 @@ class ServerManager extends EventEmitter {
     }
   }
 
+  deleteTemplate(name) {
+    if (!name || !/^[a-zA-Z0-9._-]+$/.test(name)) {
+      throw new Error('Invalid template name');
+    }
+    if (name === 'common') {
+      throw new Error('Cannot delete the reserved "common" template');
+    }
+    const templateDir = path.join(config.TEMPLATES_DIR, name);
+    if (!fs.existsSync(templateDir)) {
+      throw new Error(`Template not found: ${name}`);
+    }
+    fs.rmSync(templateDir, { recursive: true, force: true });
+  }
+
   // --- Import existing server ---
 
   async importServer(name, zipFilePath) {


### PR DESCRIPTION
Adds a "View Templates" button to the dashboard navbar that opens a modal listing all templates with their readiness status and a delete button for each.

Closes #4

Generated with [Claude Code](https://claude.ai/code)