### PR TITLE
fix: set DEFAULT_MAX_RAM to 6G, keep DEFAULT_MIN_RAM at 1024M

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ All settings are configurable via environment variables:
 | `DATA_DIR` | `./data` | Where servers.json is stored |
 | `DEFAULT_JAVA` | `java` | Path to Java binary |
 | `DEFAULT_MIN_RAM` | `1024M` | Default -Xms for new servers |
-| `DEFAULT_MAX_RAM` | `1024M` | Default -Xmx for new servers |
+| `DEFAULT_MAX_RAM` | `6G` | Default -Xmx for new servers |
 | `CONSOLE_BUFFER_SIZE` | `500` | Lines of console output buffered per server |
 | `STOP_TIMEOUT_MS` | `30000` | Milliseconds to wait for graceful stop before force-killing |
 | `BASE_MC_PORT` | `25565` | Starting port for auto-assignment |

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -10,7 +10,7 @@ const config = {
   DATA_DIR: process.env.DATA_DIR || path.join(ROOT_DIR, 'data'),
   DEFAULT_JAVA: process.env.DEFAULT_JAVA || 'java',
   DEFAULT_MIN_RAM: process.env.DEFAULT_MIN_RAM || '1024M',
-  DEFAULT_MAX_RAM: process.env.DEFAULT_MAX_RAM || '1024M',
+  DEFAULT_MAX_RAM: process.env.DEFAULT_MAX_RAM || '6G',
   CONSOLE_BUFFER_SIZE: parseInt(process.env.CONSOLE_BUFFER_SIZE, 10) || 500,
   STOP_TIMEOUT_MS: parseInt(process.env.STOP_TIMEOUT_MS, 10) || 30000,
   BASE_MC_PORT: parseInt(process.env.BASE_MC_PORT, 10) || 25565,


### PR DESCRIPTION
Change default max RAM allocation from 1024M to 6G, while keeping min RAM at 1024M.

Closes #7

Generated with [Claude Code](https://claude.ai/code)