### PR TITLE
fix: move version label to bottom right to avoid overlapping logo on …

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -29,8 +29,8 @@ body {
 /* Version label */
 .version-label {
   position: fixed;
-  top: 6px;
-  left: 8px;
+  bottom: 8px;
+  right: 8px;
   font-size: 0.65rem;
   color: #555;
   z-index: 1000;


### PR DESCRIPTION
…mobile